### PR TITLE
Enable error output to console when called from command line

### DIFF
--- a/scripts/bargraph.php
+++ b/scripts/bargraph.php
@@ -13,6 +13,8 @@ try {
 require_once ('src/jpgraph.php');
 require_once ('src/jpgraph_bar.php');
 require_once ('opjgraph.inc');
+
+if (!http_response_code()) JpGraphError::SetImageFlag(false);
  
 $dbconf = "../config/database.ini";
 $chartconf = "../config/bar.ini";
@@ -76,8 +78,8 @@ $graph->Stroke();
 } catch (JpGraphException $jge) {
 	$jge->Stroke();
 } catch (Exception $ex) {
-	throw new JpGraphException($ex);
+	throw new JpGraphException($ex->getMessage() . "\n");
 } catch (Error $er) {
-	throw new JpGraphException($er);
+	throw new JpGraphException($er->getMessage() . "\n");
 }
 ?>

--- a/scripts/linegraph.php
+++ b/scripts/linegraph.php
@@ -16,6 +16,8 @@ require_once ('src/jpgraph_date.php');
 require_once ('src/jpgraph_mgraph.php');
 require_once ('opjgraph.inc');
 
+if (!http_response_code()) JpGraphError::SetImageFlag(false);
+
 $dbconf = "../config/database.ini";
 $chartconf = "../config/line.ini";
 
@@ -131,8 +133,8 @@ if (count($graphs) == 1) {
 } catch (JpGraphException $jge) {
 	$jge->Stroke();
 } catch (Exception $ex) {
-	throw new JpGraphException($ex);
+	throw new JpGraphException($ex->getMessage() . "\n");
 } catch (Error $er) {
-	throw new JpGraphException($er);
+	throw new JpGraphException($er->getMessage() . "\n");
 }
 ?>

--- a/scripts/opjgraph.inc
+++ b/scripts/opjgraph.inc
@@ -45,7 +45,6 @@ class OPJGraph {
                 foreach ($value as $key => $value) {
                     if (is_array($value)) {
                         foreach($value as $name => $value) {
-                            //var_dump($name);
                             $values = explode(":", $value);
                             if (count($values) > 4 || count($values) < 3 || (array_search("", $values) != false)) {
                                 throw new InvalidArgumentException ("Error in item settings.");


### PR DESCRIPTION
Closes #3 

JpGraph has a built in feature to call the script from command line:

```
# php linegraph.php > /to/your/desired/location/image.png
```
Now when called from command line error output are directed to console and image containing error or exception is not drawn.

Signed-off-by Miika Jukka <miikajukka@gmail.com>